### PR TITLE
feat: enable pdf and web tools for web chat

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1,0 +1,17 @@
+import sys
+from agent.agent import chat_with_tools
+from agent.pdf_rag import ensure_pdf_index
+
+PDF_URL = (
+    "https://hcip-files.obs.sa-brazil-1.myhuaweicloud.com/HCIP-Cloud%20Service%20Solutions%20Architect%20V3.0%20Training%20Material.pdf"
+)
+
+
+def main() -> None:
+    question = " ".join(sys.argv[1:])
+    ensure_pdf_index(PDF_URL)
+    print(chat_with_tools(question))
+
+
+if __name__ == "__main__":
+    main()

--- a/server.js
+++ b/server.js
@@ -1,30 +1,37 @@
 import express from 'express';
 import { config } from 'dotenv';
-import OpenAI from 'openai';
+import { spawnSync } from 'child_process';
 
 config();
 
 const app = express();
 const port = process.env.PORT || 3000;
 
+// Ensure the PDF is downloaded and indexed so the Python agent can use it
+try {
+  spawnSync('python', [
+    '-c',
+    "from agent.pdf_rag import ensure_pdf_index; ensure_pdf_index('https://hcip-files.obs.sa-brazil-1.myhuaweicloud.com/HCIP-Cloud%20Service%20Solutions%20Architect%20V3.0%20Training%20Material.pdf')"
+  ], { stdio: 'inherit' });
+} catch (err) {
+  console.error('Failed to prepare PDF index', err);
+}
+
 app.use(express.static('public'));
 app.use(express.json());
 
-app.post('/api/chat', async (req, res) => {
+app.post('/api/chat', (req, res) => {
   const { message } = req.body;
   if (!message) {
     return res.status(400).json({ error: 'No message provided' });
   }
 
   try {
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-    const completion = await client.chat.completions.create({
-      model: 'gpt-5',
-      messages: [
-        { role: 'user', content: message }
-      ]
+    const py = spawnSync('python', ['run_agent.py', message], {
+      encoding: 'utf8',
     });
-    const answer = completion.choices[0]?.message?.content?.trim();
+    if (py.error) throw py.error;
+    const answer = py.stdout.trim();
     res.json({ answer });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- add Python bridge to answer web chat questions using RAG and web search tools
- update server to call Python agent and ensure PDF index availability

## Testing
- `npm test` (fails: Error: no test specified)
- `python run_agent.py "Who are you?"` (fails: HTTPSConnectionPool: Tunnel connection failed: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_689e3ffc457c832391ddc8aecb497555